### PR TITLE
Feature/srgg/fbr streaming values

### DIFF
--- a/connector/src/main/scala/com/basho/riak/spark/query/QueryFullBucket.scala
+++ b/connector/src/main/scala/com/basho/riak/spark/query/QueryFullBucket.scala
@@ -1,0 +1,45 @@
+package com.basho.riak.spark.query
+
+import com.basho.riak.client.api.RiakClient
+import com.basho.riak.client.api.commands.kv.FullBucketRead
+import com.basho.riak.client.core.operations.CoveragePlanOperation.Response.CoverageEntry
+import com.basho.riak.client.core.query.{RiakObject, Location}
+import com.basho.riak.client.core.util.BinaryValue
+import com.basho.riak.spark.rdd.{BucketDef, ReadConf}
+
+import scala.collection.JavaConversions._
+
+case class QueryFullBucket(bucket: BucketDef, readConf: ReadConf, coverageEntries: Iterable[CoverageEntry]) extends Query[String] {
+  override def nextChunk(nextToken: Option[_], session: RiakClient): (Option[String], Iterable[(Location, RiakObject)]) = {
+    require(coverageEntries.size == 1, "Multiple coverage entries hasn't been tested yet")
+
+    val builder = new FullBucketRead.Builder(bucket.asNamespace(), coverageEntries.head.getCoverageContext)
+      .withMaxResults(readConf.fetchSize)
+      .withPaginationSort(true)
+      .withReturnBody(true)
+
+    nextToken match {
+      case None =>
+      /* It is a first request */
+
+      case Some(continuation: String) =>
+        /* Subsequent request */
+        builder.withContinuation(BinaryValue.create(continuation))
+
+      case _ =>
+        throw new IllegalArgumentException("Wrong nextToken")
+    }
+
+    val r: FullBucketRead.Response = session.execute(builder.build())
+    val data = for {
+      e <- r.getEntries
+      n = (e.getLocation, e.getFetchedValue.getValue(classOf[RiakObject]))
+    } yield n
+
+    if(!r.hasContinuation){
+      None -> data
+    }else{
+      Some(r.getContinuation.toStringUtf8) -> data
+    }
+  }
+}

--- a/connector/src/main/scala/com/basho/riak/spark/rdd/ReadConf.scala
+++ b/connector/src/main/scala/com/basho/riak/spark/rdd/ReadConf.scala
@@ -25,7 +25,13 @@ import org.apache.spark.SparkConf
  */
 case class ReadConf (
   fetchSize: Int = ReadConf.DefaultFetchSize,
-  splitCount: Int = ReadConf.DefaultSplitCount
+  splitCount: Int = ReadConf.DefaultSplitCount,
+
+  /**
+   * DO NOT CHANGE THIS VALUES MANUALLY
+   * IT MAY CAUSE PERFORMANCE DEGRADATION
+    */
+  useStreamingValuesForFBRead: Boolean = ReadConf.DefaultUseStreamingValues4FBRead
 )
 
 object ReadConf {
@@ -34,10 +40,13 @@ object ReadConf {
   // TODO: Need to think about the proper default value
   val DefaultSplitCount = 10
 
+  val DefaultUseStreamingValues4FBRead = true
+
   def fromSparkConf(conf: SparkConf): ReadConf = {
     ReadConf(
       fetchSize = conf.getInt("spark.riak.input.fetch-size", DefaultFetchSize),
-      splitCount = conf.getInt("spark.riak.input.split.count", DefaultSplitCount)
+      splitCount = conf.getInt("spark.riak.input.split.count", DefaultSplitCount),
+      useStreamingValuesForFBRead = conf.getBoolean("spark.riak.fullbucket.use-streaming-values", DefaultUseStreamingValues4FBRead)
     )
   }
 }

--- a/connector/src/main/scala/com/basho/riak/spark/rdd/RiakRDD.scala
+++ b/connector/src/main/scala/com/basho/riak/spark/rdd/RiakRDD.scala
@@ -80,7 +80,7 @@ class RiakRDD[R] private[spark] (
 
     val query = Query(BucketDef(bucketType, bucketName), readConf, queryData)
 
-    val iterator: Iterator[(Location, RiakObject)] = new DataQueryingIterator(query, session, connector.minConnections)
+    val iterator: Iterator[(Location, RiakObject)] = DataQueryingIterator(query, session)
     val convertingIterator = new DataConvertingIterator[R](iterator, convert)
     val countingIterator = CountingIterator[R](convertingIterator)
     context.addTaskCompletionListener { (context) =>

--- a/connector/src/test/resources/log4j.properties
+++ b/connector/src/test/resources/log4j.properties
@@ -24,11 +24,11 @@ log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
 log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
 log4j.appender.CONSOLE.layout.ConversionPattern=%-5p %c %x - %m%n
 
-log4j.logger.com.basho.spark=DEBUG
+log4j.logger.com.basho.riak.spark=DEBUG
 
 
 # Turns on Riak Java Client logging
-#log4j.logger.com.basho=DEBUG
+#log4j.logger.com.basho.riak=DEBUG
 
 # Turns on low level Riak Java Client logging
 log4j.logger.io.netty.handler.logging.LoggingHandler=DEBUG

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
             <dependency>
                 <groupId>com.basho.riak</groupId>
                 <artifactId>dataplatform-riak-client</artifactId>
-                <version>1.1.0.beta1</version>
+                <version>1.1.0.beta2</version>
             </dependency>
             <dependency>
                 <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
## Full Bucket Read p2: Streaming values

### UPDATE: Ready to merge ###

### The obsolete section (for historical purposes)###
Since required changes hasn't been released yet, it requires Riak built with the following  rebar.config:

```
%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
{sub_dirs, ["rel", "apps/riak"]}.

{require_otp_vsn, "R16|17"}.
{cover_enabled, true}.

{lib_dirs, ["apps/riak"]}.

{erl_opts, [debug_info, fail_on_warning]}.
{eunit_opts, [verbose]}.

{erlydtl_opts, [
                {compiler_options, [report, return, debug_info]}
               ]}.

{deps, [
        {rebar_lock_deps_plugin, ".*", {git, "git://github.com/seth/rebar_lock_deps_plugin.git", {branch, "master"}}},
        {node_package, ".*", {git, "git://github.com/basho/node_package.git", {branch, "develop"}}},
        {lager_syslog, "2.0.3", {git, "git://github.com/basho/lager_syslog.git", {tag, "2.0.3"}}},
        {cluster_info, ".*", {git, "git://github.com/basho/cluster_info.git", {branch, "develop"}}},
        {riak_kv, ".*", {git, "git://github.com/basho/riak_kv.git", {branch, "feature/jrd/index_body"}}},
        {riak_search, ".*", {git, "git://github.com/basho/riak_search.git", {branch, "develop"}}},
        {riak_control, ".*", {git, "git://github.com/basho/riak_control.git", {branch, "develop"}}},
        {riaknostic, ".*", {git, "git://github.com/basho/riaknostic.git", {branch, "develop"}}},
        {yokozuna, ".*", {git, "git://github.com/basho/yokozuna.git", {branch, "develop"}}},
        {riak_auth_mods, ".*", {git, "git://github.com/basho/riak_auth_mods.git", {branch, "develop"}}},
        {riak_core, ".*", {git, "git://github.com/basho/riak_core.git", {branch, "feature/mrajrd/pextract"}}},
        {riak_pb, ".*", {git, "git://github.com/basho/riak_pb.git", {branch, "feature/jrd/index_body"}}},
        {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}}
       ]}.

{plugins, [rebar_lock_deps_plugin]}.
```