### PR TITLE
Fixed issue with random ordering.

### DIFF
--- a/connector/src/test/scala/com/basho/riak/spark/rdd/SparkDataframesTest.scala
+++ b/connector/src/test/scala/com/basho/riak/spark/rdd/SparkDataframesTest.scala
@@ -81,13 +81,13 @@ class SparkDataframesTest extends AbstractRDDTest {
   @Test
   def udfTest(): Unit = {
     sqlContextHolder.udf.register("stringLength", (s: String) => s.length)
-    val udf = sqlContextHolder.sql("select name, stringLength(name) strLgth from test order by strLgth").toJSON.collect
+    val udf = sqlContextHolder.sql("select name, stringLength(name) strLgth from test order by strLgth, name").toJSON.collect
     val expected = "[" +
       "{name:'Ben',strLgth:3}," +
       "{name:'John',strLgth:4}," + 
       "{name:'Mary',strLgth:4}," +
-      "{name:'Clair',strLgth:5}," +
       "{name:'Chris',strLgth:5}," +
+      "{name:'Clair',strLgth:5}," +
       "{name:'George',strLgth:6}" +
       "]"
     assertEqualsUsingJSON(expected, stringify(udf))


### PR DESCRIPTION
In a multiple nodes environment SparkDataframesTest.udfTest() sorts names with the same length randomly. Fixed this by adding additional sort by name.