### PR TITLE
Disable FBR Streaming values for OSS

### DIFF
--- a/connector/src/main/ee-resources/ee-default.properties
+++ b/connector/src/main/ee-resources/ee-default.properties
@@ -1,0 +1,12 @@
+#
+# Riak EE defaults
+#
+
+#
+# Turns on streaming values support for PEx.
+#
+# It will make Full Bucket Reads more efficient: values will be streamed as a part of the FBR response
+# instead of being fetched in a separate operations.
+#
+# Supported only by EE
+spark.riak.fullbucket.use-streaming-values=true

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,30 @@
                 <riak.test.category>com.basho.riak.spark.rdd.RiakBDPTests</riak.test.category>
             </properties>
 		</profile>
+        <profile>
+            <id>riak_bdp_ee</id>
+            <activation>
+                <property>
+                    <name>bdp_ee</name>
+                </property>
+            </activation>
+            <properties>
+                <riak.test.category>com.basho.riak.spark.rdd.RiakBDPTests</riak.test.category>
+            </properties>
+            <build>
+                <resources>
+                    <!-- process all the EE-specific resources, if any -->
+                    <resource>
+                        <directory>src/main/ee-resources</directory>
+                    </resource>
+
+                    <!-- process all other none EE-specific resources, if any -->
+                    <resource>
+                        <directory>src/main/resources</directory>
+                    </resource>
+                </resources>
+            </build>
+        </profile>
     </profiles>
 
     <modules>


### PR DESCRIPTION
To disable unsupported FBR streaming values for OSS, the default value of ReadConf.useStreamingValuesForFBRead was changed from 'true' to 'false'. The new maven profile 'riak_bdp_ee' was introduced to override OSS defaults for EE build.