### PR TITLE
Fix python serialization

### DIFF
--- a/connector/python/tests/pyspark_tests_fixtures.py
+++ b/connector/python/tests/pyspark_tests_fixtures.py
@@ -48,9 +48,7 @@ def riak_client(request):
       docker_cli = request.getfuncargvalue("docker_cli")
       nodes = get_nodes(docker_cli)
     else:
-      pb_port = 8087
-      http_port = 8098
-      nodes = [{'host': ip[:ip.index(':')], 'pb_port': pb_port, 'http_port': http_port} for ip in os.environ['RIAK_HOSTS'].split(',')]
+      nodes =[{'protocol': "pbc", 'host': t[0], 'pb_port': t[1] if len(t)>1 else "8087"} for t in  [tuple(x.strip().split(':')) for x in os.environ['RIAK_HOSTS'].split(',') ]]
     client = riak.RiakClient(nodes=nodes)
     request.addfinalizer(lambda: client.close())
     return client

--- a/connector/python/tests/test_pyspark_riak.py
+++ b/connector/python/tests/test_pyspark_riak.py
@@ -503,6 +503,28 @@ def test_kv_query_2i_range(spark_context, riak_client, sql_context):
 def test_kv_query_partition_by_2i_range(spark_context, riak_client, sql_context):
 	_test_spark_rdd_kv_read_partition_by_2i_range(10, spark_context, riak_client, sql_context)
 
+#
+# if object values are JSON objects with more than 4 keys exception happens
+# https://github.com/basho/spark-riak-connector/issues/206
+@pytest.mark.regression
+def test_read_JSON_value_with_more_then_4_fields(spark_context, riak_client):
+    bucket = riak_client.bucket("test-bucket-"+str(randint(0,100000)))
+    item = bucket.new("test-key")
+    item.data = {'field1': 'abc',
+                 'field2': 'def',
+                 'field3': 'ABC123',
+                 'field4': 'home',
+                 'field5': '10',
+                 'field6': '10.0.0.1',
+                 'field7': '1479398907',
+                 'field8': '1479398907',
+                 'field9': 'DEF456,GHI789',
+                 'field11': 'JKL000',
+                 'field12': 'abc'}
+
+    item.store()
+    result = spark_context.riakBucket(bucket.name).queryBucketKeys("test-key").collect()
+
 ###### TS Tests #######
 
 def test_ts_df_write_use_timestamp(spark_context, riak_client, sql_context):

--- a/connector/src/main/scala/com/basho/riak/spark/util/python/PicklingUtils.scala
+++ b/connector/src/main/scala/com/basho/riak/spark/util/python/PicklingUtils.scala
@@ -20,12 +20,13 @@ package com.basho.riak.spark.util.python
 import java.io.NotSerializableException
 import java.io.OutputStream
 import java.util.Collection
-import java.util.{ HashMap, Map => JMap }
+import java.util.{ HashMap => JHashMap, Map => JMap }
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable.Buffer
 import scala.collection.immutable.HashSet.{HashSet1, HashTrieSet}
 import scala.collection.immutable.Map.{ Map1, Map2, Map3, Map4, WithDefault }
+import scala.collection.immutable.HashMap. { HashMap1, HashTrieMap }
 
 import org.apache.spark.rdd.RDD
 
@@ -84,7 +85,9 @@ class PicklingUtils extends Serializable {
     Pickler.registerCustomPickler(classOf[Map2[_, _]], MapPickler)
     Pickler.registerCustomPickler(classOf[Map3[_, _]], MapPickler)
     Pickler.registerCustomPickler(classOf[Map4[_, _]], MapPickler)
-    Pickler.registerCustomPickler(classOf[HashMap[_, _]], MapPickler)
+    Pickler.registerCustomPickler(classOf[HashMap1[_, _]], MapPickler)
+    Pickler.registerCustomPickler(classOf[HashTrieMap[_, _]], MapPickler)
+    Pickler.registerCustomPickler(classOf[JHashMap[_, _]], MapPickler)
     Pickler.registerCustomPickler(classOf[JMapWrapper[_, _]], MapPickler)
   }
 }


### PR DESCRIPTION
fixes for #206

Python: if object values are JSON objects with more than 4 keys exception happens